### PR TITLE
EMP feature

### DIFF
--- a/contracts/NukeFund/NukeFund.sol
+++ b/contracts/NukeFund/NukeFund.sol
@@ -175,7 +175,7 @@ contract NukeFund is INukeFund, ReentrancyGuard, Ownable, Pausable {
       : potentialClaimAmount;
 
     fund -= claimAmount; // Deduct the claim amount from the fund
-    uint256 entropy = TraitForgeNft.getTokenEntropy(tokenId);
+    uint256 entropy = nftContract.getTokenEntropy(tokenId);
     nftContract.burn(tokenId); // Burn the token
     (bool success, ) = payable(msg.sender).call{ value: claimAmount }('');
     require(success, 'Failed to send Ether');


### PR DESCRIPTION
How it works is, 1/10 NFTs (if its entropy % 10 == 7), then it is an EMP nft. meaning when it nukes, it will run a function called checkEMP, if its entropy aligns, it will set isEMPActive to true. this pauses the nuke function. the time it unlock is based upon the entropy. on base, block time is 2 seconds. so an entropy of (999999 / 10) (in the calculation) is roughly 2.3 days of blocks. so after 2.3 days of waiting, when somebody tries to nuke and the require statement is satisfied, it will reset back to false and nuking will be available again. hopefully this makes sense. lmk if you. have any questions